### PR TITLE
build: upgrade Spring Data dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 		<registry.version>2.5.1-SNAPSHOT</registry.version>
 		<org.springframework-version>4.3.17.RELEASE</org.springframework-version>
 		<org.springframework.security-version>4.1.1.RELEASE</org.springframework.security-version>
-		<org.springframework.data-version>1.7.2.RELEASE</org.springframework.data-version>
+		<org.springframework.data-version>1.7.4.RELEASE</org.springframework.data-version>
  		<org.springframework.batch-version>3.0.4.RELEASE</org.springframework.batch-version>
 		<org.hibernate-version>4.3.10.Final</org.hibernate-version>
 		<org.hibernate.validator-version>5.0.1.Final</org.hibernate.validator-version>

--- a/src/registry-api/src/main/java/de/geoinfoffm/registry/api/security/RegistryUserDetailsManager.java
+++ b/src/registry-api/src/main/java/de/geoinfoffm/registry/api/security/RegistryUserDetailsManager.java
@@ -53,10 +53,10 @@ import de.geoinfoffm.registry.core.security.RegistrySecurity;
 
 public class RegistryUserDetailsManager implements UserDetailsManager, GroupManager
 {
-	@Autowired
-	private RegistryUserRepository userRepository;
+	private final RegistryUserRepository userRepository;
 	
-	public RegistryUserDetailsManager() {
+	public RegistryUserDetailsManager(RegistryUserRepository userRepository) {
+		this.userRepository = userRepository;
 	}
 
 	@Override

--- a/src/registry-core/pom.xml
+++ b/src/registry-core/pom.xml
@@ -75,11 +75,6 @@
 			<artifactId>spring-context-support</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.data</groupId>
-			<artifactId>spring-data-commons</artifactId>
-			<version>${org.springframework.data-version}</version>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
 			<version>3.1</version>

--- a/src/registry-persistence/pom.xml
+++ b/src/registry-persistence/pom.xml
@@ -81,12 +81,18 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-jpa</artifactId>
-			<version>1.4.1.RELEASE</version>
+			<version>${org.springframework.data-version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-envers</artifactId>
 			<version>0.1.0.RELEASE</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.springframework.data</groupId>
+					<artifactId>spring-data-commons-core</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/src/registry-persistence/src/main/java/de/geoinfoffm/registry/persistence/EntityBackendFactoryBean.java
+++ b/src/registry-persistence/src/main/java/de/geoinfoffm/registry/persistence/EntityBackendFactoryBean.java
@@ -44,15 +44,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.GenericTypeResolver;
 import org.springframework.data.envers.repository.support.EnversRevisionRepositoryFactoryBean;
 import org.springframework.data.envers.repository.support.ReflectionRevisionEntityInformation;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.support.JpaEntityInformation;
 import org.springframework.data.jpa.repository.support.JpaRepositoryFactory;
+import org.springframework.data.jpa.repository.support.SimpleJpaRepository;
 import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.data.repository.core.support.RepositoryFactorySupport;
 import org.springframework.data.repository.history.RevisionRepository;
 import org.springframework.data.repository.history.support.RevisionEntityInformation;
 import org.springframework.security.acls.model.MutableAclService;
-import org.springframework.stereotype.Component;
 
 import de.geoinfoffm.registry.core.AuditedRepository;
 
@@ -134,7 +133,7 @@ public class EntityBackendFactoryBean extends EnversRevisionRepositoryFactoryBea
 		 */
 		@Override
 		@SuppressWarnings({ "unchecked", "rawtypes" })
-		protected <T, ID extends Serializable> JpaRepository<?, ?> getTargetRepository(RepositoryMetadata metadata,
+		protected <T, ID extends Serializable> SimpleJpaRepository<?, ?> getTargetRepository(RepositoryMetadata metadata,
 				EntityManager entityManager) {
 
 			JpaEntityInformation<T, Serializable> entityInformation = 

--- a/src/registry-persistence/src/main/java/de/geoinfoffm/registry/persistence/EntityRepositoryImpl.java
+++ b/src/registry-persistence/src/main/java/de/geoinfoffm/registry/persistence/EntityRepositoryImpl.java
@@ -80,7 +80,7 @@ public class EntityRepositoryImpl<T extends Entity> extends AuditedRepositoryImp
 	}
 
 	@Override
-	public T saveAndFlush(T entity) {
+	public <S extends T> S saveAndFlush(S entity) {
 		entity = super.saveAndFlush(entity);
 		createAcl(entity);
 		return entity;


### PR DESCRIPTION
Upgrades Spring Data to 1.7.4 to prevent `NoSuchMethodError`s during runtime. Also prevents pulling in a wrong version of `spring-data-commons-core` via Envers & adapts interfaces to the new library versions where necessary.