### PR TITLE
Fix registry initialization and add additional checks for submitted proposals

### DIFF
--- a/src/registry-api/src/main/java/de/geoinfoffm/registry/api/AbstractRegistryInitializer.java
+++ b/src/registry-api/src/main/java/de/geoinfoffm/registry/api/AbstractRegistryInitializer.java
@@ -210,7 +210,7 @@ public abstract class AbstractRegistryInitializer implements RegistryInitializer
 				ic.setName(name);
 			}
 			log(String.format("> Adding item class '%s' to register '%s'...", name, r.getName()));
-			r.getContainedItemClasses().add(ic);
+			r.addContainedItemClass(ic);
 			ic = itemClassRepository.save(ic);
 			r = registerRepository.save(r);
 

--- a/src/registry-api/src/main/java/de/geoinfoffm/registry/api/ProposalServiceImpl.java
+++ b/src/registry-api/src/main/java/de/geoinfoffm/registry/api/ProposalServiceImpl.java
@@ -355,12 +355,18 @@ public class ProposalServiceImpl extends AbstractApplicationService<Proposal, Pr
 
 		// check target register
 		final UUID targetRegisterUuid = proposal.getTargetRegisterUuid();
+		if (targetRegisterUuid == null) {
+			throw new InvalidProposalException("The target register must be specified.");
+		}
 		final RE_Register targetRegister = registerRepository.findOne(targetRegisterUuid);
 		if (!targetRegister.getContainedItemClasses().contains(itemClass)) {
 			throw new InvalidProposalException(String.format("Item of item class '%s' is not allowed in target register '%s'.", itemClass.getName(), targetRegister.getName()));
 		}
 //		logger.debug(">>> Target register: {}", targetRegister.getName());
 		
+		if (proposal.getSponsorUuid() == null) {
+			throw new InvalidProposalException("The submitting organisation must be specified.");
+		}
 		RE_SubmittingOrganization sponsor = submittingOrgRepository.findOne(proposal.getSponsorUuid());
 		if (sponsor == null) {
 			// try organization UUID

--- a/src/registry-core/src/main/java/de/geoinfoffm/registry/core/model/iso19135/RE_Register.java
+++ b/src/registry-core/src/main/java/de/geoinfoffm/registry/core/model/iso19135/RE_Register.java
@@ -404,6 +404,13 @@ public class RE_Register extends de.geoinfoffm.registry.core.Entity
 		this.containedItemClasses = containedItemClasses;
 	}
 	
+	public void addContainedItemClass(RE_ItemClass containedItemClass) {
+		if (this.containedItemClasses == null) {
+			this.containedItemClasses = new LinkedHashSet<RE_ItemClass>();
+		}
+		this.containedItemClasses.add(containedItemClass);
+	}
+
 	/**
 	 * @return the submitter
 	 */


### PR DESCRIPTION
Makes sure that the RE_ItemClass is actually added. The previous implementation added the RE_ItemClass to the list returnd by `getContainedItemClasses()` which contained only a copy of the `containedItemClasses` member.

Also adds additional checks to the proposal service to validate proposal objects submitted to the API.