### PR TITLE
Updates for proposal groups and item identifier assignment

### DIFF
--- a/src/registry-api/src/main/java/de/geoinfoffm/registry/api/ProposalListItemImpl.java
+++ b/src/registry-api/src/main/java/de/geoinfoffm/registry/api/ProposalListItemImpl.java
@@ -407,7 +407,7 @@ public class ProposalListItemImpl implements ProposalListItem
 	@Override
 	@JsonProperty
 	public boolean isGroup() {
-		return ProposalGroup.class.getName().equals(this.getProposalType());
+		return ProposalGroup.class.getName().equals(proposal.getClass().getName());
 	}
 	
 	/* (non-Javadoc)

--- a/src/registry-api/src/main/java/de/geoinfoffm/registry/api/ProposalService.java
+++ b/src/registry-api/src/main/java/de/geoinfoffm/registry/api/ProposalService.java
@@ -77,7 +77,8 @@ public interface ProposalService extends ApplicationService<Proposal>
 	Proposal updateProposal(RegisterItemProposalDTO proposal) throws InvalidProposalException, UnauthorizedException;
 	Proposal updateProposal(UUID proposalUuid, AbstractProposal_Type proposal) throws InvalidProposalException;
 	Supersession updateSupersession(Supersession supersession, Set<RE_RegisterItem> supersededItems, Set<RE_RegisterItem> existingSuccessors, Set<RegisterItemProposalDTO> newSuccessors, String justification, String registerManagerNotes, String controlBodyNotes) throws InvalidProposalException;
-	
+	ProposalGroup updateProposalGroup(ProposalGroup group, List<Proposal> containedProposals, String title) throws InvalidProposalException;
+
 	Proposal withdrawProposal(Proposal proposal) throws InvalidProposalException, IllegalOperationException;
 	void deleteProposal(Proposal proposal) throws IllegalOperationException, UnauthorizedException;
 

--- a/src/registry-api/src/main/java/de/geoinfoffm/registry/api/ProposalServiceImpl.java
+++ b/src/registry-api/src/main/java/de/geoinfoffm/registry/api/ProposalServiceImpl.java
@@ -1265,6 +1265,31 @@ public class ProposalServiceImpl extends AbstractApplicationService<Proposal, Pr
 	}
 
 	@Override
+	public ProposalGroup updateProposalGroup(ProposalGroup group, List<Proposal> containedProposals, String title) throws InvalidProposalException {
+		if (StringUtils.isEmpty(title)) {
+			throw new InvalidProposalException("Title must not be empty");
+		}
+
+		for (Proposal proposal : containedProposals) {
+			if (!group.getProposals().contains(proposal)) {
+				group.addProposal(proposal);
+			}
+		}
+
+		for (Proposal proposal : group.getProposals()) {
+			if (!containedProposals.contains(proposal)) {
+				group.removeProposal(proposal);
+			}
+		}
+
+		group.setTitle(title);
+
+		group = proposalRepository.save(group);
+
+		return group;
+	}
+
+	@Override
 	public Appeal findAppeal(UUID uuid) {
 		return appealRepository.findOne(uuid);
 	}

--- a/src/registry-api/src/main/java/de/geoinfoffm/registry/api/RegisterItemFactoryImpl.java
+++ b/src/registry-api/src/main/java/de/geoinfoffm/registry/api/RegisterItemFactoryImpl.java
@@ -45,7 +45,6 @@ import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
 import org.apache.commons.lang.math.RandomUtils;
-import org.eclipse.persistence.internal.jpa.EntityManagerFactoryProvider;
 import org.isotc211.iso19135.RE_RegisterItem_Type;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.BeansException;
@@ -225,16 +224,9 @@ public class RegisterItemFactoryImpl<I extends RE_RegisterItem, P extends Regist
 
 		proposal.setAdditionalValues(item, entityManager);
 
-		// The following call to findMaxitemIdentifer() leads to the result
-		// entity being saved prematurely. To prevent a ConstraintException,
-		// set a random negative value here.
+		// Sets a random negative item identifier. The final (positive) identifier has to be
+		// set as part of the proposal workflow.
 		item.setItemIdentifier(BigInteger.valueOf(-RandomUtils.nextInt()));
-
-		BigInteger maxIdentifier = itemService.findMaxItemIdentifier();
-		if (maxIdentifier == null) {
-			maxIdentifier = BigInteger.ZERO;
-		}
-		item.setItemIdentifier(maxIdentifier.add(BigInteger.ONE));
 	}
 
 	// private Map<String, Object> getBeans() {


### PR DESCRIPTION
When a `RegisterItem` is first created (e.g. as part of an addition proposal), the system will now assign a temporary negative item identifier. This negative identifier will be overwritten by a final positive identifier once the item is accepted into the register. In the ISO Geodetic Registry this is handled by the class `IsoProposalServiceImpl`.

This change does not affect existing items or the existing registration process. It allows, however, for a more consistent way to handle item identifier assignments when continuous identifiers are desired for the registered items.

Also adds a method to update proposal groups and fixes the way groups are detected in `ProposalListItem`.