### PR TITLE
feat: allow copying properties from a register item to a proposal

### DIFF
--- a/src/registry-api/src/main/java/de/geoinfoffm/registry/api/RegisterItemProposalDTO.java
+++ b/src/registry-api/src/main/java/de/geoinfoffm/registry/api/RegisterItemProposalDTO.java
@@ -317,7 +317,12 @@ public class RegisterItemProposalDTO
 		
 		this.loadAdditionalValues(item);
 	}
-	
+
+	public void copyProperties(RE_RegisterItem source) {
+		initializeFromItem(source);
+		this.setItemUuid(null);
+	}
+
 	/**
 	 * Must be overwritten by extending classes to set additional
 	 * property values.


### PR DESCRIPTION
Creates an API method to copy properties from an existing `RE_RegisterItem` to a `RegisterItemProposalDTO`.

https://github.com/ISO-TC211/iso-geodetic-registry/issues/82