### PR TITLE
fix: fix detection of dependent proposals

### DIFF
--- a/src/registry-api/src/main/java/de/geoinfoffm/registry/api/RegisterItemProposalDTO.java
+++ b/src/registry-api/src/main/java/de/geoinfoffm/registry/api/RegisterItemProposalDTO.java
@@ -754,8 +754,10 @@ public class RegisterItemProposalDTO
 	protected List<RegisterItemProposalDTO> findDependentProposals(RegisterItemProposalDTO... dtos) {
 		List<RegisterItemProposalDTO> dependentProposals = new ArrayList<RegisterItemProposalDTO>();
 		for (RegisterItemProposalDTO dto : dtos) {
-//			if (dto != null && dto.getItemUuid() != null && dto.getReferencedItemUuid() == null) {
-			if (dto != null && dto.getReferencedItemUuid() == null) {
+			// Checking for non-empty name to differentiate between a reference
+			// being left intentionally empty and an actual nested proposal. In
+			// both cases, referencedItemUuid will be null.
+			if (dto != null && dto.getReferencedItemUuid() == null && !StringUtils.isEmpty(dto.getName())) {
 				dependentProposals.add(dto);
 			}
 		}


### PR DESCRIPTION
Adds an additional check when detecting dependent/nested proposals to make sure
that in case an item reference is intentionally left empty by the user, the
`RegisterItemProposalDTO` is not interpreted as a proposal for a new item
unless the mandatory `name` property is filled.